### PR TITLE
Add missing comma to acceptableExtensions list.

### DIFF
--- a/include/ReadLibrary.hpp
+++ b/include/ReadLibrary.hpp
@@ -53,7 +53,7 @@ public:
     bool checkFileExtensions_(std::vector<std::string>& filenames, std::stringstream& errorStream) {
         namespace bfs = boost::filesystem;
 
-        std::set<std::string> acceptableExensions = {".FASTA", ".FASTQ", ".FA", ".FQ"
+        std::set<std::string> acceptableExensions = {".FASTA", ".FASTQ", ".FA", ".FQ",
                                                      ".fasta", ".fastq", ".fa", ".fq"};
         bool extensionsOK{true};
         for (auto& fn : filenames) {


### PR DESCRIPTION
I think that without the comma, the ".FQ" and ".fasta" extensions won't be accepted?
