### PR TITLE
Fix bad link to RTD on README (fastio branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@
 Documentation
 ==============
 
-The documentation for Salmon and Sailfish is being migrated to [ReadTheDocs](www.readthedocs.org).
+The documentation for Salmon and Sailfish is being migrated to [ReadTheDocs](http://readthedocs.org).
 To see [the latest documentation there](http://sailfish.readthedocs.org).


### PR DESCRIPTION
Since the protocol is not specified, GitHub interprets the link as being in the same domain. This PR fixes the link.
