### PR TITLE
Fix missing includes

### DIFF
--- a/include/ReadExperiment.hpp
+++ b/include/ReadExperiment.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <fstream>
 #include <atomic>
+#include <numeric>
 
 #include "UtilityFunctions.hpp"
 #include "ReadKmerDist.hpp"

--- a/src/SailfishQuantify.cpp
+++ b/src/SailfishQuantify.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <fstream>
+#include <random>
 #include <vector>
 #include <thread>
 


### PR DESCRIPTION
Include `<random>`
Fix `error: no type named 'random_device' in namespace 'std'`

Include `<numeric>`
Fix `error: no member named 'iota' in namespace 'std'`

Closes #92